### PR TITLE
Refactor to make customizing behavior easier

### DIFF
--- a/spectrify/convert.py
+++ b/spectrify/convert.py
@@ -14,7 +14,7 @@ from multiprocessing import Pool, cpu_count
 import click
 from spectrify.utils.timestamps import iso8601_to_nanos
 from spectrify.utils.parquet import Writer
-from spectrify.utils.s3 import get_fs, S3GZipCSVReader
+from spectrify.utils.s3 import S3GZipCSVReader
 
 # This determines the number of rows in each row group of the Parquet file.
 # Larger row group means better compression.
@@ -24,141 +24,7 @@ from spectrify.utils.s3 import get_fs, S3GZipCSVReader
 # are required in memory for processing.
 SPECTRIFY_ROWS_PER_GROUP = environ.get('SPECTRIFY_ROWS_PER_GROUP') or 250000
 
-
-class PoolManager(object):
-    """Pool in Python 2 doesn't act as a context manager. So just make one here"""
-    def __init__(self, *args, **kwargs):
-        self.pool_args = args
-        self.pool_kwargs = kwargs
-        self.pool = None
-
-    def __enter__(self):
-        self.pool = Pool(*(self.pool_args), **(self.pool_kwargs))
-        return self.pool
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        self.pool.close()
-        self.pool.join()
-
-
-def convert_redshift_manifest_to_parquet(manifest_path, sa_table, out_dir, workers=None):
-    """Parses manifest file and then converts each referenced file"""
-
-    with get_fs().open(manifest_path) as manifest_file:
-        manifest = json.loads(manifest_file.read().decode('utf-8'))
-    num_files = len(manifest['entries'])
-
-    workers = workers or min(num_files, cpu_count())
-    click.echo('Converting {} csv files to parquet with {} workers.'.format(num_files, workers))
-
-    if workers > 1:
-        convert_parallel(manifest, sa_table, out_dir, workers)
-    else:
-        convert_synchronous(manifest, sa_table, out_dir)
-
-
-def convert_parallel(manifest, sa_table, out_dir, workers):
-    convert_args = [(entry['url'], sa_table, out_dir) for entry in manifest['entries']]
-
-    with PoolManager(workers) as pool:
-        pool.map(_parallel_wrapper, convert_args, chunksize=1)
-
-
-def _parallel_wrapper(arg_tuple):
-    data_path, sa_table, out_dir = arg_tuple
-    convert_csv_file_to_parquet(data_path, sa_table, out_dir)
-
-
-def convert_synchronous(manifest, sa_table, out_dir):
-    for entry in manifest['entries']:
-        convert_csv_file_to_parquet(entry['url'], sa_table, out_dir)
-
-
-def convert_csv_file_to_parquet(data_path, sa_table, out_dir):
-    """Converts an individual datafile on S3 to parquet"""
-    filename, ext = path.splitext(path.basename(data_path))
-    out_path = path.join(out_dir, filename)
-    if not out_path.endswith('.parq'):
-        out_path += '.parq'
-
-    click.echo('Converting file [%s] to [%s]' % (data_path, out_path))
-
-    with get_fs().open(out_path, 'wb') as s3_file:
-        with Writer(s3_file, sa_table) as writer:
-
-            # Read the data in chunks (to control memory usage) and write to parquet.
-            # The obvious choice is to use Pandas for this, but issues with null values and
-            # difficulty with type conversions were a blocker when I originally wrote this code.
-            # It's possible the situation has evolved.
-            #
-            # Assuming those issues have solutions, using Pandas would probably be much more
-            # efficient in terms of CPU and memory.
-            for chunk in columnar_data_chunks(data_path, sa_table, SPECTRIFY_ROWS_PER_GROUP):
-                writer.write_row_group(chunk)
-
-    click.echo('Done converting file [%s] to [%s]' % (data_path, out_path))
-
-
-def _clear_and_collect(data):
-    for col in data:
-        col.clear()
-
-    # Explicitly run garbage collector; previous data isn't needed anymore
-    # and will just add unnecessary memory pressure until python decides
-    # it's worth running
-    gc.collect()
-
-
-def _convert_to_type(value, py_type):
-    """Converts the CSV string element to an intermediary python datatype
-    This is necessary because Arrow can't parse strings itself, it expects
-    an intermediary data type (actual type is determined by the destination
-    arrow datatype)
-    """
-    if value == '':
-        value = None
-    elif py_type:
-        value = py_type(value)
-    return value
-
-
-def columnar_data_chunks(data_path, sa_table, chunk_size):
-    """A generator function that returns chunk_size rows (or whatever is left
-    at the end of the file) in columnar format
-    This function also performs conversion from string to python datatype based on the given
-    SQLAlchemy schema.
-    """
-
-    # An array of functions corresponding to the CSV columns that take a string and return the
-    # corresponding Python datatype
-    type_converters = table_to_conversion_funcs(sa_table)
-
-    with S3GZipCSVReader(data_path, delimiter='|', escapechar='\\', quoting=csv.QUOTE_NONE) as reader:
-        num_cols = len(sa_table.columns)
-        col_indices = range(num_cols)
-        data = [list() for i in range(num_cols)]
-
-        # Read in CSV and store it by column (makes passing to Arrow easier)
-        for row in reader:
-            # read a row
-            for i in col_indices:
-                value = row[i]
-                py_type = type_converters[i]
-
-                value = _convert_to_type(value, py_type)
-                data[i].append(value)
-
-            if len(data[0]) == chunk_size:
-                yield data
-                _clear_and_collect(data)
-
-        # Number of rows in file is not necessarily divisible by chunk_size
-        # So make sure there isn't any lingering data to process
-        if data[0]:
-            yield data
-            _clear_and_collect(data)
-
-
+# These are the values Redshift uses for true/false in its CSVs
 POSTGRES_TRUE_VAL = 't'
 POSTGRES_FALSE_VAL = 'f'
 
@@ -198,6 +64,142 @@ if sys.version_info[0] < 3:
     })
 
 
-def table_to_conversion_funcs(sa_table):
-    cols = sa_table.columns
-    return [string_converters.get(col.type.python_type) for col in cols]
+class CsvConverter:
+    def __init__(self, s3_config, sa_table, **kwargs):
+        self.s3_config = s3_config
+        self.sa_table = sa_table
+        self.kwargs = kwargs
+
+    def log(self, msg):
+        """By default, we log to console with click"""
+        click.echo(msg)
+
+    def get_manifest(self):
+        with self.s3_config.fs_open(self.s3_config.get_manifest_path()) as manifest_file:
+            return json.loads(manifest_file.read().decode('utf-8'))
+
+    def convert_csv(self, file_path):
+        """Converts an individual datafile on S3 to parquet"""
+        filename, ext = path.splitext(path.basename(file_path))
+        out_dir = self.s3_config.get_spectrum_dir()
+        out_path = path.join(out_dir, filename)
+        if not out_path.endswith('.parq'):
+            out_path += '.parq'
+
+        self.log('Converting file [%s] to [%s]' % (file_path, out_path))
+
+        with self.s3_config.fs_open(out_path, 'wb') as s3_file:
+            with Writer(s3_file, self.sa_table) as writer:
+                # Read the data in chunks (to control memory usage) and write to parquet.
+                # The obvious choice is to use Pandas for this, but issues with null values and
+                # difficulty with type conversions were a blocker when I originally wrote this code.
+                # It's possible the situation has evolved.
+                #
+                # Assuming those issues have solutions, using Pandas would probably be much more
+                # efficient in terms of CPU and memory.
+                for chunk in self.columnar_data_chunks(file_path, self.sa_table, SPECTRIFY_ROWS_PER_GROUP):
+                    writer.write_row_group(chunk)
+
+        self.log('Done converting file [%s] to [%s]' % (file_path, out_path))
+
+    def _clear_and_collect(self, data):
+        for col in data:
+            col.clear()
+
+        # Explicitly run garbage collector; previous data isn't needed anymore
+        # and will just add unnecessary memory pressure until python decides
+        # it's worth running
+        gc.collect()
+
+    def _convert_to_type(self, value, py_type):
+        """Converts the CSV string element to an intermediary python datatype
+        This is necessary because Arrow can't parse strings itself, it expects
+        an intermediary data type (actual type is determined by the destination
+        arrow datatype)
+        """
+        if value == '':
+            value = None
+        elif py_type:
+            value = py_type(value)
+        return value
+
+    def columnar_data_chunks(self, data_path, sa_table, chunk_size):
+        """A generator function that returns chunk_size rows (or whatever is left
+        at the end of the file) in columnar format
+        This function also performs conversion from string to python datatype based on the given
+        SQLAlchemy schema.
+        """
+
+        # An array of functions corresponding to the CSV columns that take a string and return the
+        # corresponding Python datatype
+        type_converters = self.table_to_conversion_funcs(sa_table)
+
+        with S3GZipCSVReader(self.s3_config, data_path, delimiter='|', escapechar='\\', quoting=csv.QUOTE_NONE) as reader:
+            num_cols = len(sa_table.columns)
+            col_indices = range(num_cols)
+            data = [list() for i in range(num_cols)]
+
+            # Read in CSV and store it by column (makes passing to Arrow easier)
+            for row in reader:
+                # read a row
+                for i in col_indices:
+                    value = row[i]
+                    py_type = type_converters[i]
+
+                    value = self._convert_to_type(value, py_type)
+                    data[i].append(value)
+
+                if len(data[0]) == chunk_size:
+                    yield data
+                    self._clear_and_collect(data)
+
+            # Number of rows in file is not necessarily divisible by chunk_size
+            # So make sure there isn't any lingering data to process
+            if data[0]:
+                yield data
+                self._clear_and_collect(data)
+
+    def table_to_conversion_funcs(self, sa_table):
+        cols = sa_table.columns
+        return [string_converters.get(col.type.python_type) for col in cols]
+
+
+class _PoolManager(object):
+    """Pool in Python 2 doesn't act as a context manager. So just make one here"""
+
+    def __init__(self, *args, **kwargs):
+        self.pool_args = args
+        self.pool_kwargs = kwargs
+        self.pool = None
+
+    def __enter__(self):
+        self.pool = Pool(*(self.pool_args), **(self.pool_kwargs))
+        return self.pool
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.pool.close()
+        self.pool.join()
+
+
+def _parallel_wrapper(arg_tuple):
+    data_path, sa_table, s3_config = arg_tuple
+    CsvConverter(s3_config, sa_table).convert_csv(data_path)
+
+
+class ConcurrentManifestConverter(CsvConverter):
+    """Converts CSV files concurrently using a multiprocessing pool."""
+
+    def convert_manifest(self):
+        num_workers = self.kwargs.get('num_workers') or cpu_count()
+        manifest = self.get_manifest()
+        convert_args = [(entry['url'], self.sa_table, self.s3_config) for entry in manifest['entries']]
+
+        with _PoolManager(num_workers) as pool:
+            pool.map(_parallel_wrapper, convert_args, chunksize=1)
+
+
+class SimpleManifestConverter(CsvConverter):
+    def convert_manifest(self):
+        manifest = self.get_manifest()
+        for entry in manifest['entries']:
+            self.convert_csv(entry['url'])

--- a/spectrify/create.py
+++ b/spectrify/create.py
@@ -1,60 +1,82 @@
+from __future__ import absolute_import, division, print_function
+from future.standard_library import install_aliases
+install_aliases()  # noqa
+
 import click
 from sqlalchemy.schema import CreateColumn
 from sqlalchemy import Column, types
 from sqlalchemy.dialects.postgresql import DOUBLE_PRECISION
-
-create_query = """
-create external table {table_name} (
-    {column_list}
-)
-stored as parquet
-location '{s3_location}'
-"""
 
 type_map = {
     DOUBLE_PRECISION: types.FLOAT,  # Replace postgres-specific with more generic
 }
 
 
-def create_external_table(engine, schema_name, table_name, sa_table, s3_path):
-    cols = list(sa_table.columns)
-
-    # If we are converting a table from another schema, include the schema
-    # in the table name.
-    table_name = table_name.replace('.', '_')
-
-    col_descriptors = []
-    for col in cols:
-        # We only want the column name and type.
-        # There are no NOT NULL, DEFAULT, etc. clauses in Spectrum
-        # Also, we need to replace some types.
-        rs_col_cls = col.type.__class__
-        if rs_col_cls in type_map:
-            spectrum_col_type = type_map[rs_col_cls]()
-        else:
-            spectrum_col_type = col.type
-        spectrum_col = Column(col.description, spectrum_col_type)
-
-        # OK, now get the actual SQL snippet for the column
-        statement = CreateColumn(spectrum_col).compile().statement
-
-        col_descriptors.append(str(statement))
-    col_ddl = ',\n    '.join(col_descriptors)
-
-    formatted_query = create_query.format(
-        table_name='.'.join([schema_name, table_name]),
-        column_list=col_ddl,
-        s3_location=s3_path,
+class SpectrumTableCreator:
+    create_query = """
+    create external table {table_name} (
+        {column_list}
     )
+    stored as parquet
+    location '{s3_location}'
+    """
 
-    click.echo('')
-    click.echo('*** CREATE TABLE SQL ***')
-    click.echo(formatted_query)
-    click.echo('')
-    click.confirm('Continue?', abort=True)
+    def __init__(self, engine, schema_name, table_name, sa_table, s3_config):
+        self.engine = engine
+        self.schema_name = schema_name
+        self.table_name = table_name
+        self.sa_table = sa_table
+        self.s3_config = s3_config
+        self.query = self.format_query()
 
-    with engine.connect() as cursor:
-        cursor.execution_options(isolation_level='AUTOCOMMIT')
-        click.echo('Creating table...')
-        cursor.execute(formatted_query)
-        click.echo('Done.')
+    def log(self, msg):
+        """By default, we log to console with click"""
+        click.echo(msg)
+
+    def format_query(self):
+        cols = list(self.sa_table.columns)
+
+        # If we are converting a table from another schema, include the schema
+        # in the table name.
+        table_name = self.table_name.replace('.', '_')
+
+        col_descriptors = []
+        for col in cols:
+            # We only want the column name and type.
+            # There are no NOT NULL, DEFAULT, etc. clauses in Spectrum
+            # Also, we need to replace some types.
+            rs_col_cls = col.type.__class__
+            if rs_col_cls in type_map:
+                spectrum_col_type = type_map[rs_col_cls]()
+            else:
+                spectrum_col_type = col.type
+            spectrum_col = Column(col.description, spectrum_col_type)
+
+            # OK, now get the actual SQL snippet for the column
+            statement = CreateColumn(spectrum_col).compile().statement
+
+            col_descriptors.append(str(statement))
+
+        col_ddl = ',\n    '.join(col_descriptors)
+
+        return self.create_query.format(
+            table_name='.'.join([self.schema_name, table_name]),
+            column_list=col_ddl,
+            s3_location=self.s3_config.get_spectrum_dir(),
+        )
+
+    def create(self):
+        with self.engine.connect() as cursor:
+            cursor.execution_options(isolation_level='AUTOCOMMIT')
+            self.log('Creating table...')
+            cursor.execute(self.query)
+            self.log('Done.')
+
+    def log_query(self):
+        self.log('')
+        self.log('*** CREATE TABLE SQL ***')
+        self.log(self.query)
+        self.log('')
+
+    def confirm(self):
+        click.confirm('Continue?', abort=True)

--- a/spectrify/export.py
+++ b/spectrify/export.py
@@ -1,32 +1,44 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
+from future.standard_library import install_aliases
+install_aliases()  # noqa
+
 import boto3
 import click
 
-UNLOAD_QUERY = """
-UNLOAD ('select * from {}')
-to %(s3_path)s
-CREDENTIALS %(credentials)s
-ESCAPE MANIFEST GZIP ALLOWOVERWRITE
-MAXFILESIZE 1 gb;
-"""
 
+class RedshiftDataExporter:
+    UNLOAD_QUERY = """
+    UNLOAD ('select * from {}')
+    to %(s3_path)s
+    CREDENTIALS %(credentials)s
+    ESCAPE MANIFEST GZIP ALLOWOVERWRITE
+    MAXFILESIZE 1 gb;
+    """
 
-def export_to_csv(engine, table_name, s3_csv_path):
-    session = boto3.Session()
-    credentials = session.get_credentials()
-    creds_str = 'aws_access_key_id={};aws_secret_access_key={}'.format(
-        credentials.access_key,
-        credentials.secret_key,
-    )
+    def __init__(self, sa_engine, s3_config):
+        self.sa_engine = sa_engine
+        self.s3_config = s3_config
 
-    formatted_query = UNLOAD_QUERY.format(table_name)
-    with engine.connect() as cursor:
-        click.echo('Exporting table to CSV...')
-        cursor.execute(formatted_query, {
-            's3_path': s3_csv_path,
-            'credentials': creds_str,
-        })
-        click.echo('Done.')
+    def export_to_csv(self, table_name):
+        s3_path = self.s3_config.get_csv_dir()
+        creds_str = self.get_credentials()
+        query = self.get_query(table_name)
 
-    manifest_path = s3_csv_path + 'manifest'
-    return manifest_path
+        with self.sa_engine.connect() as cursor:
+            click.echo('Exporting table to CSV...')
+            cursor.execute(query, {
+                's3_path': s3_path,
+                'credentials': creds_str,
+            })
+            click.echo('Done.')
+
+    def get_query(self, table_name):
+        return self.UNLOAD_QUERY.format(table_name)
+
+    def get_credentials(self):
+        session = boto3.Session()
+        credentials = session.get_credentials()
+        return 'aws_access_key_id={};aws_secret_access_key={}'.format(
+            credentials.access_key,
+            credentials.secret_key,
+        )

--- a/spectrify/utils/schema.py
+++ b/spectrify/utils/schema.py
@@ -1,56 +1,47 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import pyarrow as pa
 import sqlalchemy as sa
-from sqlalchemy.dialects.postgresql import DOUBLE_PRECISION, TIMESTAMP
+from spectrify.utils.parquet import pyarrow_type_map
 
 
-def _pa_timestamp_ns():
-    """Wrapper function around Arrow's timestamp type function, which is the
-    only type function that requires an argument...
-    """
-    return pa.timestamp('ns')
+class SchemaReader:
+    def get_table_schema(self, table_name):
+        """Returns a SqlAlchemy schema.  Schema provides column names and
+        data types for use during format conversions
+        """
+        raise NotImplementedError('Must be implemented by subclass')
 
 
-# Map between SqlAlchemy type classes and pyarrow/parquet type generator functions.
-sa_type_map = {
-    sa.types.BIGINT: pa.int64,
-    sa.types.INTEGER: pa.int32,
-    sa.types.SMALLINT: pa.int16,
-    sa.types.FLOAT: pa.float64,
-    DOUBLE_PRECISION: pa.float64,
-    sa.types.VARCHAR: pa.string,
-    sa.types.NVARCHAR: pa.string,
-    sa.types.CHAR: pa.string,
-    sa.types.BOOLEAN: pa.bool_,
-    sa.types.TIMESTAMP: _pa_timestamp_ns,
-    TIMESTAMP: _pa_timestamp_ns,
-}
+class SqlAlchemySchemaReader(SchemaReader):
+    """Map between SqlAlchemy type classes and pyarrow/parquet type generator
+    functions."""
 
+    def __init__(self, engine):
+        self.engine = engine
+        self.metadata = sa.MetaData(self.engine)
 
-def get_table_schema(engine, table_name):
-    meta = sa.MetaData(engine)
-    schema_name = None
+    def get_table_schema(self, table_name):
+        schema_name = None
 
-    # Handle table name prepended with schema
-    parts = table_name.split('.')
-    if len(parts) == 2:
-        schema_name, table_name = parts
+        # Handle table name prepended with schema
+        parts = table_name.split('.')
+        if len(parts) == 2:
+            schema_name, table_name = parts
 
-    table = sa.Table(
-        table_name,
-        meta,
-        autoload=True,
-        postgresql_ignore_search_path=True,
-        schema=schema_name
-    )
+        table = sa.Table(
+            table_name,
+            self.metadata,
+            autoload=True,
+            postgresql_ignore_search_path=True,
+            schema=schema_name
+        )
 
-    for col in table.columns:
-        if col.type.__class__ not in sa_type_map:
-            raise ValueError(
-                'Type {} not currently supported by Spectrify. Open an issue?'.format(
-                    col.type.__class__
+        for col in table.columns:
+            if col.type.__class__ not in pyarrow_type_map:
+                raise ValueError(
+                    'Type {} not currently supported by Spectrify. Open an issue?'.format(
+                        col.type.__class__
+                    )
                 )
-            )
 
-    return table
+        return table


### PR DESCRIPTION
Prior to this PR, Spectrify was more or less a collection of nested functions.  This made code reuse very difficult and costly to maintain for anyone who might want to customize some aspect of the project's behavior.

This refactor introduces a number of classes, which will make the project easier to work with and customize, as inheritance can be used to override a particular behavior without rewriting everything.

This will require a major version bump, as there are a number of backwards-incompatible changes.