### PR TITLE
Update file size when exporting tables to S3

### DIFF
--- a/spectrify/export.py
+++ b/spectrify/export.py
@@ -12,7 +12,7 @@ class RedshiftDataExporter:
     to %(s3_path)s
     CREDENTIALS %(credentials)s
     ESCAPE MANIFEST GZIP ALLOWOVERWRITE
-    MAXFILESIZE 1 gb;
+    MAXFILESIZE 256 mb;
     """
 
     def __init__(self, sa_engine, s3_config):


### PR DESCRIPTION
Moving to 256 mb as discussed in https://github.com/hellonarrativ/spectrify/issues/29