### PR TITLE
Adding REGION parameter to UNLOAD

### DIFF
--- a/spectrify/export.py
+++ b/spectrify/export.py
@@ -12,6 +12,7 @@ class RedshiftDataExporter:
     to %(s3_path)s
     CREDENTIALS %(credentials)s
     ESCAPE MANIFEST GZIP ALLOWOVERWRITE
+    REGION 'us-east-1'
     MAXFILESIZE 256 mb;
     """
 


### PR DESCRIPTION
The region parameter is necessary for the unload function. If it's not there, S3 raises an error:
"S3ServiceException:The bucket you are attempting to access must be addressed using the specified endpoint. Please send all future requests to this endpoint.,Status 301,Error PermanentRedirect".

Please keep in mind that my pull request is just an example. "us-east-1" should not be hard coded. It should be asked as a parameter beforehand.