### PR TITLE
Add support for s3 region parameter when unloading Redshift table

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -9,5 +9,5 @@ Sphinx==1.8.3
 cryptography==2.4.2
 pandas==0.23.4
 PyYAML==4.2b2
-pytest==4.1.0
+pytest==4.6.6
 pytest-runner==4.2

--- a/spectrify/convert.py
+++ b/spectrify/convert.py
@@ -222,7 +222,10 @@ class ConcurrentManifestConverter(CsvConverter):
         num_workers = self.kwargs.get('num_workers') or cpu_count()
         manifest = self.get_manifest()
         convert_args = [
-            (entry['url'], self.sa_table, self.s3_config, self.delimiter, self.escapechar, self.quoting, self.unicode_csv)
+            (
+                entry['url'], self.sa_table, self.s3_config, self.delimiter,
+                self.escapechar, self.quoting, self.unicode_csv
+            )
             for entry in manifest['entries']
         ]
 

--- a/spectrify/create.py
+++ b/spectrify/create.py
@@ -12,6 +12,7 @@ type_map = {
     DOUBLE_PRECISION: types.FLOAT,  # Replace postgres-specific with more generic
 }
 
+
 class TableCreator(object):
     __metaclass__ = abc.ABCMeta
 

--- a/spectrify/export.py
+++ b/spectrify/export.py
@@ -38,7 +38,10 @@ class RedshiftDataExporter:
     def get_credentials(self):
         session = boto3.Session()
         credentials = session.get_credentials()
-        return 'aws_access_key_id={};aws_secret_access_key={}'.format(
-            credentials.access_key,
-            credentials.secret_key,
-        )
+        creds_str = 'aws_access_key_id={};aws_secret_access_key={}'.format(
+                credentials.access_key,
+                credentials.secret_key,
+            )
+        if credentials.token:
+            creds_str += ';token={}'.format(credentials.token)
+        return creds_str

--- a/spectrify/export.py
+++ b/spectrify/export.py
@@ -8,10 +8,11 @@ import click
 
 class RedshiftDataExporter:
     UNLOAD_QUERY = """
-    UNLOAD ('select * from {}')
+    UNLOAD ('select * from {table_name}')
     to %(s3_path)s
     CREDENTIALS %(credentials)s
     ESCAPE MANIFEST GZIP ALLOWOVERWRITE
+    {region_config}
     MAXFILESIZE 256 mb;
     """
 
@@ -33,7 +34,12 @@ class RedshiftDataExporter:
             click.echo('Done.')
 
     def get_query(self, table_name):
-        return self.UNLOAD_QUERY.format(table_name)
+        region_config = ''
+        if self.s3_config.get_bucket_region():
+            region_config = 'REGION \'{}\''.format(self.s3_config.get_bucket_region())
+        return self.UNLOAD_QUERY.format(
+            table_name=table_name,
+            region_config=region_config)
 
     def get_credentials(self):
         session = boto3.Session()

--- a/spectrify/main.py
+++ b/spectrify/main.py
@@ -36,7 +36,7 @@ def cli(ctx, **kwargs):
 def transform(ctx, table, s3_path, dest_schema, dest_table, s3_region):
     dest_table = dest_table or table
     engine = get_sa_engine(ctx)
-    s3_config = SimpleS3Config.from_base_path(s3_path, s3_region)
+    s3_config = SimpleS3Config.from_base_path(s3_path, region=s3_region)
     transformer = TableTransformer(engine, table, s3_config, dest_schema, dest_table)
     transformer.transform()
 
@@ -48,7 +48,7 @@ def transform(ctx, table, s3_path, dest_schema, dest_table, s3_region):
 @click.pass_context
 def export(ctx, table, s3_path, s3_region):
     engine = get_sa_engine(ctx)
-    s3_config = SimpleS3Config.from_base_path(s3_path, s3_region)
+    s3_config = SimpleS3Config.from_base_path(s3_path, region=s3_region)
     RedshiftDataExporter(engine, s3_config).export_to_csv(table)
 
 

--- a/spectrify/main.py
+++ b/spectrify/main.py
@@ -31,11 +31,12 @@ def cli(ctx, **kwargs):
 @click.argument('s3_path')
 @click.option('--dest-schema', default='spectrum')
 @click.option('--dest-table')
+@click.option('--s3-region')
 @click.pass_context
-def transform(ctx, table, s3_path, dest_schema, dest_table):
+def transform(ctx, table, s3_path, dest_schema, dest_table, s3_region):
     dest_table = dest_table or table
     engine = get_sa_engine(ctx)
-    s3_config = SimpleS3Config.from_base_path(s3_path)
+    s3_config = SimpleS3Config.from_base_path(s3_path, s3_region)
     transformer = TableTransformer(engine, table, s3_config, dest_schema, dest_table)
     transformer.transform()
 
@@ -43,10 +44,11 @@ def transform(ctx, table, s3_path, dest_schema, dest_table):
 @cli.command()
 @click.argument('table')
 @click.argument('s3_path')
+@click.option('--s3-region')
 @click.pass_context
-def export(ctx, table, s3_path):
+def export(ctx, table, s3_path, s3_region):
     engine = get_sa_engine(ctx)
-    s3_config = SimpleS3Config.from_base_path(s3_path)
+    s3_config = SimpleS3Config.from_base_path(s3_path, s3_region)
     RedshiftDataExporter(engine, s3_config).export_to_csv(table)
 
 

--- a/spectrify/utils/s3.py
+++ b/spectrify/utils/s3.py
@@ -52,19 +52,18 @@ class SimpleS3Config(S3Config):
     """A simple pattern for those who dont already have a data layout"""
 
     @classmethod
-    def from_base_path(cls, base_path, region, **kwargs):
+    def from_base_path(cls, base_path, **kwargs):
         csv_dir = '/'.join([base_path, 'csv', ''])
         return cls(
             csv_dir,
             '/'.join([base_path, 'spectrum', '']),
-            region,
             **kwargs
         )
 
-    def __init__(self, csv_dir, spectrum_dir, region):
+    def __init__(self, csv_dir, spectrum_dir, **kwargs):
         self.csv_dir = csv_dir
         self.spectrum_dir = spectrum_dir
-        self.region = region
+        self.region = kwargs.get('region', '')
 
     def get_manifest_path(self):
         return self.csv_dir + 'manifest'

--- a/spectrify/utils/s3.py
+++ b/spectrify/utils/s3.py
@@ -52,17 +52,19 @@ class SimpleS3Config(S3Config):
     """A simple pattern for those who dont already have a data layout"""
 
     @classmethod
-    def from_base_path(cls, base_path, **kwargs):
+    def from_base_path(cls, base_path, region, **kwargs):
         csv_dir = '/'.join([base_path, 'csv', ''])
         return cls(
             csv_dir,
             '/'.join([base_path, 'spectrum', '']),
+            region,
             **kwargs
         )
 
-    def __init__(self, csv_dir, spectrum_dir):
+    def __init__(self, csv_dir, spectrum_dir, region):
         self.csv_dir = csv_dir
         self.spectrum_dir = spectrum_dir
+        self.region = region
 
     def get_manifest_path(self):
         return self.csv_dir + 'manifest'
@@ -72,6 +74,9 @@ class SimpleS3Config(S3Config):
 
     def get_spectrum_dir(self):
         return self.spectrum_dir
+
+    def get_bucket_region(self):
+        return self.region
 
 
 class S3GZipCSVReader:

--- a/tests/test_csv_converter.py
+++ b/tests/test_csv_converter.py
@@ -10,6 +10,7 @@ import sqlalchemy
 from spectrify.convert import CsvConverter
 from spectrify.utils.s3 import SimpleS3Config
 
+
 def get_stream(stream):
     if sys.version_info[0] < 3:
         return stream

--- a/tests/test_csv_converter.py
+++ b/tests/test_csv_converter.py
@@ -65,7 +65,8 @@ class TestCsvConverter(TestCase):
             delimiter=delimiter,
             quoting=quoting,
             csv_dir="",
-            spectrum_dir=""
+            spectrum_dir="",
+            region=""
         )
         csv_converter = CsvConverter(sa_table, s3_config, delimiter=delimiter, quoting=quoting)
         columnar_data_chunks = [

--- a/tests/test_open_csv_serde_table_creator.py
+++ b/tests/test_open_csv_serde_table_creator.py
@@ -25,7 +25,7 @@ class TestOpenCSVSerdeTableCreator(TestCase):
                 'compression_type'='gzip'
             );
         """
-        s3_config = SimpleS3Config.from_base_path("s3://some_bucket/prefix")
+        s3_config = SimpleS3Config.from_base_path("s3://some_bucket/prefix", "eu-west-1")
         sa_meta = sqlalchemy.MetaData()
         sa_table = sqlalchemy.Table(
             'unit_test_table',

--- a/tests/test_open_csv_serde_table_creator.py
+++ b/tests/test_open_csv_serde_table_creator.py
@@ -25,7 +25,7 @@ class TestOpenCSVSerdeTableCreator(TestCase):
                 'compression_type'='gzip'
             );
         """
-        s3_config = SimpleS3Config.from_base_path("s3://some_bucket/prefix", "eu-west-1")
+        s3_config = SimpleS3Config.from_base_path("s3://some_bucket/prefix")
         sa_meta = sqlalchemy.MetaData()
         sa_table = sqlalchemy.Table(
             'unit_test_table',

--- a/tests/test_util_s3.py
+++ b/tests/test_util_s3.py
@@ -7,6 +7,7 @@ import unicodecsv as csv
 
 from spectrify.utils.s3 import S3GZipCSVReader
 
+
 class FakeS3Config(object):
     def __init__(self, fileobj):
         self.fileobj = fileobj
@@ -14,6 +15,7 @@ class FakeS3Config(object):
     def fs_open(self, *args, **kwargs):
         self.fileobj.seek(0)
         return self.fileobj
+
 
 class TestUtilsS3CSVReader(TestCase):
     def test_s3_gzip_csv_reader(self):


### PR DESCRIPTION
Hello there and thanks for this useful piece of software 👍 

My initial idea was to implement only https://github.com/hellonarrativ/spectrify/issues/50 but I ended up doing a bit more to have the tests/linter pass and to be able to do the functional tests with my current aws config. That's why you'll find the 4 following commits :
- bump the pytest dependency which was broken (https://stackoverflow.com/questions/58189683/typeerror-attrib-got-an-unexpected-keyword-argument-convert)
- fix a few flake8 errors
- add the support for using the `aws_session_token` when getting the credentials from boto3 which I needed to test with my current aws setup
- implement https://github.com/hellonarrativ/spectrify/issues/50

For the two features I have added, I didn't implement any unit tests since they are related to configuration so hardly testable. However I have manually tested that all the cases work and are backward compatible: wether you use an `aws_session_token` in your config or not, and wether you specify the `--s3-region` param while using the cli or not, the code will still work the exact same way and run fine.

Hope this can help and be merged (because we are currently using it in a professional setup and need those features).
Cheers!