### PR TITLE
Remove psycopg2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ requirements = [
     'Click',
     'future',
     'pandas',
-    'psycopg2',
     'pyarrow>=0.9.0',
     'python-dateutil<2.7.0,>=2.1',
     's3fs',


### PR DESCRIPTION
`sqlalchemy-redshift` no longer provides this `psycopg2` allowing the user to choose between `psycopg2` and `psycopg2-binary` so this overrides the choice if bundled together